### PR TITLE
fix: use url which opens chat by default

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <script>
-  const APP_URL = 'https://www.bing.com/?FORM=Z9FD1';
+  const APP_URL = 'https://www.bing.com/search?q=Bing+AI&showconv=1';
   window.location.replace(APP_URL);
 </script>


### PR DESCRIPTION
Works for me at least. Not sure if this URL will change in future, it likely will. Maybe see if it works for you? Or was that url already putting you on the chat page?